### PR TITLE
Temporarily Hide Phone Numbers

### DIFF
--- a/app/javascript/components/history/HistoryVue.vue
+++ b/app/javascript/components/history/HistoryVue.vue
@@ -3,7 +3,7 @@
         <div class="row">
             <div v-if="claimedByUser" class="small-12 medium-12 large-12 columns">
                 <b>Claimed By: </b><a
-                    :href="'mailto:' + claimedByUser.u_email">{{claimedByUser.u_name}}</a>, {{claimedByUser.u_mobile | phone}}
+                    :href="'mailto:' + claimedByUser.u_email">{{claimedByUser.u_name}}</a>
                 <br/>
                 <b>Organization: </b><a
                     :href="'<%= worker_incident_legacy_organizations_path %>/' + claimedByUser.lg_id">{{claimedByUser.lg_name}}</a>

--- a/app/javascript/history.js
+++ b/app/javascript/history.js
@@ -1,7 +1,6 @@
 Vue.filter('phone', function (phone) {
-  return phone.replace(.,''); //Temporarily hide phone number until we can re-train phone center staff
-  //replace(/[^0-9]/g, '')
-    //.replace(/(\d{3})(\d{3})(\d{4})/, '($1) $2-$3');
+  return phone.replace(/[^0-9]/g, '')
+    .replace(/(\d{3})(\d{3})(\d{4})/, '($1) $2-$3');
 });
 
 import Vue from 'vue';

--- a/app/javascript/history.js
+++ b/app/javascript/history.js
@@ -1,6 +1,7 @@
 Vue.filter('phone', function (phone) {
-  return phone.replace(/[^0-9]/g, '')
-    .replace(/(\d{3})(\d{3})(\d{4})/, '($1) $2-$3');
+  return phone.replace(.,''); //Temporarily hide phone number until we can re-train phone center staff
+  //replace(/[^0-9]/g, '')
+    //.replace(/(\d{3})(\d{3})(\d{4})/, '($1) $2-$3');
 });
 
 import Vue from 'vue';

--- a/app/views/worker/incident/legacy_contacts/_show_table.html.erb
+++ b/app/views/worker/incident/legacy_contacts/_show_table.html.erb
@@ -21,7 +21,7 @@
           	<%= contact.email %>
         </td>
         <td> 
-        	<!--<%= contact.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
+        	Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
         </td>
         <td>
           	<%= contact.title %>

--- a/app/views/worker/incident/legacy_contacts/_show_table.html.erb
+++ b/app/views/worker/incident/legacy_contacts/_show_table.html.erb
@@ -21,7 +21,7 @@
           	<%= contact.email %>
         </td>
         <td> 
-        	<%= contact.phone %> 
+        	<!--<%= contact.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
         </td>
         <td>
           	<%= contact.title %>

--- a/app/views/worker/incident/legacy_contacts/_table.html.erb
+++ b/app/views/worker/incident/legacy_contacts/_table.html.erb
@@ -21,7 +21,7 @@
             <%= contact.email %>
         </td>
         <td> 
-          <!--<%= contact.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
+          Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
         </td>
         <td>
             <%= contact.title %>

--- a/app/views/worker/incident/legacy_contacts/_table.html.erb
+++ b/app/views/worker/incident/legacy_contacts/_table.html.erb
@@ -21,7 +21,7 @@
             <%= contact.email %>
         </td>
         <td> 
-          <%= contact.phone %> 
+          <!--<%= contact.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
         </td>
         <td>
             <%= contact.title %>

--- a/app/views/worker/incident/legacy_organizations/_contacts_table.html.erb
+++ b/app/views/worker/incident/legacy_organizations/_contacts_table.html.erb
@@ -24,7 +24,7 @@
             <%= contact.email %>
         </td>
         <td> 
-          <!--<%= contact.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
+          Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
         </td>
         <td>
             <%= contact.title %>

--- a/app/views/worker/incident/legacy_organizations/_contacts_table.html.erb
+++ b/app/views/worker/incident/legacy_organizations/_contacts_table.html.erb
@@ -24,7 +24,7 @@
             <%= contact.email %>
         </td>
         <td> 
-          <%= contact.phone %> 
+          <!--<%= contact.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
         </td>
         <td>
             <%= contact.title %>

--- a/app/views/worker/incident/legacy_organizations/_show_table.html.erb
+++ b/app/views/worker/incident/legacy_organizations/_show_table.html.erb
@@ -21,7 +21,7 @@
             <%= organization.email %>
         </td>
         <td>
-            <!--<%= organization.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
+            Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
         </td>
         <td>
             <%= organization.url %>

--- a/app/views/worker/incident/legacy_organizations/_show_table.html.erb
+++ b/app/views/worker/incident/legacy_organizations/_show_table.html.erb
@@ -21,7 +21,7 @@
             <%= organization.email %>
         </td>
         <td>
-            <%= organization.phone %>
+            <!--<%= organization.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a>
         </td>
         <td>
             <%= organization.url %>

--- a/app/views/worker/incident/legacy_organizations/_table.html.erb
+++ b/app/views/worker/incident/legacy_organizations/_table.html.erb
@@ -18,7 +18,7 @@
           </a>
         </td>
         <td> <%= org.email %> </td>
-        <td> <!--<%= org.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a></td>
+        <td> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a></td>
         <td> <%= org.url %> </td>
         <td> <a href="<%=worker_incident_legacy_contact_path(event_id, org.primary_contact_id(org.id)) if org.primary_contact_id(org.id)%>"><%= org.primary_contact_name(org.id) %></a> </td>
         <td>

--- a/app/views/worker/incident/legacy_organizations/_table.html.erb
+++ b/app/views/worker/incident/legacy_organizations/_table.html.erb
@@ -18,7 +18,7 @@
           </a>
         </td>
         <td> <%= org.email %> </td>
-        <td> <%= org.phone %> </td>
+        <td> <!--<%= org.phone %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a></td>
         <td> <%= org.url %> </td>
         <td> <a href="<%=worker_incident_legacy_contact_path(event_id, org.primary_contact_id(org.id)) if org.primary_contact_id(org.id)%>"><%= org.primary_contact_name(org.id) %></a> </td>
         <td>

--- a/app/views/worker/incident/legacy_sites/map.html.erb
+++ b/app/views/worker/incident/legacy_sites/map.html.erb
@@ -42,7 +42,7 @@
         <h4>Site History</h4>
         <div class="row">
           <div class="small-12 medium-12 large-12 columns">
-            <p style="font-size: smaller">WARNING: DO NOT SHARE THIS INFORMATION WITH SURVIVORS. This information is for internal coordination use only. If you are not a member of a volunteer's organization, you may not tell them what to do, or when to deploy. If you don't follow these instructions, we will have to take away your nice things and use paper plates instead of china.</p>
+            <p style="font-size: smaller">WARNING: DO NOT SHARE THIS INFORMATION WITH SURVIVORS (This has already been a <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">problem</a>). This information is for internal coordination use only. If you are not a member of a volunteer's organization, you may not tell them what to do, or when to deploy. If you don't follow these instructions, we will have to take away your nice things and use paper plates instead of china.</p>
           </div>
         </div>
         <div v-show="hasError" class="row">

--- a/app/views/worker/my_organization/_user_table.html.erb
+++ b/app/views/worker/my_organization/_user_table.html.erb
@@ -15,7 +15,7 @@
           <td> <%= user.name %> </td>
           <td> <%= user.role %> </td>
           <td> <%= user.email %> </td>
-          <td> <%= number_to_phone(user.mobile) %> </td>
+          <td> <!--<%= number_to_phone(user.mobile) %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a></td>
           <td> <%= user.last_sign_in_at.strftime("%m/%d/%Y") if user.last_sign_in_at %> </td>
         </tr>
       <% end %>

--- a/app/views/worker/my_organization/_user_table.html.erb
+++ b/app/views/worker/my_organization/_user_table.html.erb
@@ -15,7 +15,7 @@
           <td> <%= user.name %> </td>
           <td> <%= user.role %> </td>
           <td> <%= user.email %> </td>
-          <td> <!--<%= number_to_phone(user.mobile) %>--> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a></td>
+          <td> Temporarily <a href="http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html" target="_blank">Hidden</a></td>
           <td> <%= user.last_sign_in_at.strftime("%m/%d/%Y") if user.last_sign_in_at %> </td>
         </tr>
       <% end %>


### PR DESCRIPTION
This hotfix temporarily hides all user, contact, and organizational
phone numbers, due to call center staff sharing it with the public. See:
http://blog.crisiscleanup.org/2017/09/internal-phone-numbers-hidden.html