### PR TITLE
Remove unopened comment close tag

### DIFF
--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -35,7 +35,7 @@
 			</table>
 			</p>
 			<p>Crisis Cleanup LLC, a New Jersey LLC, is the agent for this implementation of the <a href="https://github.com/CrisisCleanup/crisiscleanup">Crisis Cleanup project</a>.</p>
-			<p>Please donate through our <a href="/donate">Patreon Page</a>.</p>-->
+			<p>Please donate through our <a href="/donate">Patreon Page</a>.</p>
 			<p>Thank you for your time and interest.</p>
         </div>
 


### PR DESCRIPTION
Noticed a dangling close tag on the contact us page. Pull request is to remove the close, but perhaps the intent was to comment out the pateron link? 

![image](https://user-images.githubusercontent.com/1011814/31029724-db5982f8-a520-11e7-9912-220e9347ac27.png)


https://www.crisiscleanup.org/contact

Crisis Cleanup LLC, a New Jersey LLC, is the agent for this implementation of the Crisis Cleanup project.

Please donate through our Patreon Page.

-->
Thank you for your time and interest.