### PR TITLE
Fix unverified orgs admin table to align headers

### DIFF
--- a/app/views/admin/dashboard/_org_table.html.erb
+++ b/app/views/admin/dashboard/_org_table.html.erb
@@ -32,9 +32,6 @@
         <td>
               <%= org.created_at %>
         </td>
-        <td>
-            <%= org.name %>
-        </td>
         <% if org.legacy_contacts.where(is_primary:true).count > 0 %>
           <td> <%= org.legacy_contacts.where(is_primary: true).first.first_name %> <%= org.legacy_contacts.where(is_primary: true).first.last_name %> </td>
           <td> <%= org.legacy_contacts.where(is_primary: true).first.email %> </td>


### PR DESCRIPTION
👋

Issue #424

There was an extra `td` entry being added for each data row causing the columns to be misaligned.

Perhaps @andygimma or @dmehrotra would be good reviewers as they have worked on the source in question before.

