### PR TITLE
Restructure printed work order form to allow for written data by work teams

### DIFF
--- a/app/views/worker/incident/legacy_sites/print.html.erb
+++ b/app/views/worker/incident/legacy_sites/print.html.erb
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>CrisisCleanup - Print Case Number <%= @site.case_number %></title>
@@ -735,34 +735,34 @@
   </td>
 </tr>
 <tr class="sizing">
-  <td width="50"></td>
-  <td width="50"></td>
+  <td width="52"></td>
+  <td width="51"></td>
+  <td width="30"></td>
+  <td width="7"></td>
+  <td width="14"></td>
+  <td width="14"></td>
+  <td width="14"></td>
+  <td width="14"></td>
+  <td width="14"></td>
+  <td width="12"></td>
+  <td width="12"></td>
+  <td width="12"></td>
   <td width="10"></td>
-  <td width="5"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
+  <td width="7"></td>
   <td width="10"></td>
-  <td width="5"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="19"></td>
-  <td width="64"></td>
   <td width="10"></td>
-  <td width="5"></td>
-  <td width="5"></td>
-  <td width="50"></td>
-  <td width="94"></td>
-  <td width="94"></td>
   <td width="10"></td>
+  <td width="10"></td>
+  <td width="12"></td>
+  <td width="11"></td>
+  <td width="44"></td>
+  <td width="17"></td>
+  <td width="7"></td>
+  <td width="7"></td>
+  <td width="37"></td>
+  <td width="71"></td>
+  <td width="71"></td>
+  <td width="20"></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Minor column reformatting of printed work order, primarily to allow for hours worked to be written in, but also to vertically shrink the page and prevent some multi-page bleed by 1-3 lines.